### PR TITLE
Upgrade tweepy remove oauth2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,3 @@
-httplib2
-oauth2
-urwid
-tweepy >2.2,<3
+httplib2==0.9
+urwid==1.3.0
+tweepy==3.1.0

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,8 @@ import turses
 NAME = "turses"
 
 REQUIREMENTS = [
-    "oauth2",
     "urwid",
-    "tweepy >2.2,<3",
+    "tweepy==3.1.0",
 ]
 if version_info[:2] == (2, 6):
     REQUIREMENTS.append("argparse")

--- a/turses/api/backends.py
+++ b/turses/api/backends.py
@@ -165,14 +165,14 @@ class TweepyApi(BaseTweepyApi, ApiAdapter):
     def init_api(self):
         oauth_handler = TweepyOAuthHandler(
             self._consumer_key,
-            self._consumer_secret,
-            secure=configuration.twitter['use_https'])
+            self._consumer_secret)
+
+        oauth_handler.secure = configuration.twitter['use_https']
 
         oauth_handler.set_access_token(self._access_token_key,
                                        self._access_token_secret)
 
-        self._api = BaseTweepyApi(oauth_handler,
-                                  secure=configuration.twitter['use_https'])
+        self._api = BaseTweepyApi(oauth_handler)
 
     @to_user
     def verify_credentials(self):


### PR DESCRIPTION
**Work in Progress** don't merge, but have a look @dialelo if you have some time. Thanks :beers: :)

Scope of this guy is to just rely on the most recent `tweepy` to take advantage of `requests_oauth`, which currently is wrapped by `tweepy`

I would like to add some test coverage even if pre-existing tests are passing in my local, let's see the Travis guy

Might solve https://github.com/dialelo/turses/issues/190