### PR TITLE
turses: config: fix py3k conversion

### DIFF
--- a/turses/config.py
+++ b/turses/config.py
@@ -756,8 +756,7 @@ class Configuration(object):
                 elif style == 'statuses_in_user_info':
                     self.styles[style] = conf.getint(SECTION_STYLES, style)
                 else:
-                    self.styles[style] = str(
-                        conf.get(SECTION_STYLES, style), 'utf-8')
+                    self.styles[style] = conf.get(SECTION_STYLES, style)
 
     def _parse_debug(self, conf):
         if conf.has_option(SECTION_DEBUG, 'logging_level'):


### PR DESCRIPTION
The py3k conversion didn't properly fix the config loading code.

Fixes: bfc1d3160ef7 ("python3 port")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>