### PR TITLE
tweepy: downgrade to working v3.1.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
 httplib2==0.9
 urwid==1.3.0
-tweepy==3.3.0
+tweepy==3.1.0
 future==0.14.3

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ NAME = "turses"
 
 REQUIREMENTS = [
     "urwid==1.3.0",
-    "tweepy==3.3.0",
+    "tweepy==3.1.0",
     "future==0.14.3",
 ]
 if version_info[:2] == (2, 6):


### PR DESCRIPTION
In v3.2.0, tweepy broke their API, making it impossible to post a status
without changing your caller code. A PR is currently open to fix this,
so until that's merged with upstream, we'll just run an older (but
working) version of tweepy.

Fixes: #208
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>