### PR TITLE
fix for tweepy==3.3.0

### DIFF
--- a/turses/api/backends.py
+++ b/turses/api/backends.py
@@ -293,10 +293,10 @@ class TweepyApi(BaseTweepyApi, ApiAdapter):
         return self._api.retweets_of_me(**kwargs)
 
     def update(self, text):
-        self._api.update_status(text)
+        self._api.update_status(status=text)
 
     def reply(self, status, text):
-        self._api.update_status(text, in_reply_to_status_id=status.id)
+        self._api.update_status(status=text, in_reply_to_status_id=status.id)
 
     def destroy_status(self, status):
         self._api.destroy_status(status.id)


### PR DESCRIPTION
tweepy==3.3.0 introduces the following error:

ERROR:root:[{u'message': u'media_ids parameter is invalid.', u'code': 44}]
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/turses/meta.py", line 35, in wrapper
    result = func(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/turses/api/base.py", line 311, in update
    self._api.update(text)
  File "/usr/local/lib/python2.7/site-packages/turses/api/backends.py", line 296, in update
    self._api.update_status(text)
  File "/usr/local/lib/python2.7/site-packages/tweepy/api.py", line 193, in update_status
    )(post_data=post_data, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/tweepy/binder.py", line 239, in _call
    return method.execute()
  File "/usr/local/lib/python2.7/site-packages/tweepy/binder.py", line 223, in execute
    raise TweepError(error_msg, resp)
TweepError: [{u'message': u'media_ids parameter is invalid.', u'code': 44}]

This is due to the first positional argument to the update_status() method being interpreted as the media_ids parameter. Explicitly naming the status parameter avoids the error.

Fix in tweepy looks to be merged in 3.4.0. https://github.com/tweepy/tweepy/pull/578